### PR TITLE
Add IsSavingConfigurable=true to FileTypeOptions

### DIFF
--- a/src/JpegXLFileType.cs
+++ b/src/JpegXLFileType.cs
@@ -34,8 +34,9 @@ namespace JpegXLFileTypePlugin
             {
                 LoadExtensions = FileExtensions,
                 SaveExtensions = FileExtensions,
-                SupportsCancellationExceptions = true,
-                SupportsSavingLayers = false
+                SupportsSavingLayers = false,
+                IsSavingConfigurable = true,
+                SupportsCancellationExceptions = true
             })
         {
             if (host != null)


### PR DESCRIPTION
This has to be specified now. Before it was inferred based on whether `FileType.OnCreateDefaultSaveConfigToken()` was implemented or not