### PR TITLE
Update JxlFileTypeIO.vcxproj

### DIFF
--- a/src/JxlFileTypeIO/Decoder/JxlDecoder.cpp
+++ b/src/JxlFileTypeIO/Decoder/JxlDecoder.cpp
@@ -814,7 +814,7 @@ namespace
             {
                 size_t remaining = JxlDecoderReleaseBoxBuffer(context.GetDecoder());
 
-                boxMetadataBufferOffset += boxMetadataChunkSize - remaining;
+                boxMetadataBufferOffset = boxMetadataBuffer.size() - remaining;
                 boxMetadataBuffer.resize(boxMetadataBuffer.size() + boxMetadataChunkSize);
 
                 if (JxlDecoderSetBoxBuffer(


### PR DESCRIPTION
The boxMetadataBufferOffset calculation would cause data corruption for buffers over 131072 bytes in size.

Closes #19

cc @rickbrew